### PR TITLE
feat: Add async threadpooled wrapper for `sled::Db`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,6 +3179,7 @@ dependencies = [
  "snafu",
  "strata-p2p-db",
  "strata-p2p-wire",
+ "threadpool",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3200,7 +3201,9 @@ dependencies = [
  "serde_json",
  "sled",
  "snafu",
+ "threadpool",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3336,6 +3339,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ snafu = { version = "0.8.5", default-features = false, features = [
   "backtrace",
   "std",
 ] }
+threadpool = "1.8.1"
 tokio = { version = "1.42.0", default-features = false, features = [
   "macros",
   "time",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -11,11 +11,14 @@ musig2.workspace = true
 prost.workspace = true
 serde.workspace = true
 snafu.workspace = true
+tracing.workspace = true
 
 # make this implementation optional
 sled = "0.34.7"
 # temporaty solution for DB serialization. `ciborium` crate is not working, unfortunatly.
 serde_json = "1.0.135"
+threadpool.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt"] }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -8,7 +8,7 @@ use snafu::{ResultExt, Snafu};
 use crate::states::PeerDepositState;
 
 mod prost_serde;
-mod sled;
+pub mod sled;
 pub mod states;
 
 pub type DBResult<T> = Result<T, RepositoryError>;

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 snafu = { workspace = true, features = ["rust_1_81", "backtrace", "std"] }
 strata-p2p-db.path = "../db"
 strata-p2p-wire.path = "../wire"
+threadpool.workspace = true
 tokio = { workspace = true, features = ["macros", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true

--- a/crates/p2p/tests/common.rs
+++ b/crates/p2p/tests/common.rs
@@ -1,12 +1,13 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use libp2p::{identity::secp256k1::Keypair as SecpKeypair, Multiaddr, PeerId};
 use snafu::ResultExt;
 use strata_p2p::swarm::{self, handle::P2PHandle, P2PConfig, P2P};
+use strata_p2p_db::sled::AsyncDB;
 use tokio_util::sync::CancellationToken;
 
 pub struct Operator {
-    pub p2p: P2P<(), sled::Db>,
+    pub p2p: P2P<(), AsyncDB>,
     pub handle: P2PHandle<()>,
 }
 
@@ -34,7 +35,8 @@ impl Operator {
 
         let swarm = swarm::with_inmemory_transport(&config)
             .whatever_context("failed to initialize swarm")?;
-        let (p2p, handle) = P2P::<(), sled::Db>::from_config(config, cancel, db, swarm)
+        let db = AsyncDB::new(Default::default(), Arc::new(db));
+        let (p2p, handle) = P2P::<(), AsyncDB>::from_config(config, cancel, db, swarm)
             .whatever_context("invalid p2p config")?;
 
         Ok(Self { handle, p2p })


### PR DESCRIPTION
## Description

Add async threadpooled wrapper for `sled::Db`

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I mimicked what macro from [`strata-storage`](https://github.com/alpenlabs/strata/blob/main/crates/storage/src/exec.rs) does  with generation of async methods for DB with channels for `get_raw` and `set_raw` methods.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
