### PR TITLE
refactor: Use `SessionId` instead of `Scope` for nonces and signatures exchange messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,6 +3195,7 @@ dependencies = [
 name = "strata-p2p-types"
 version = "0.1.0"
 dependencies = [
+ "bitcoin",
  "hex",
  "libp2p-identity",
  "serde",

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use bitcoin::{hashes::sha256, OutPoint, XOnlyPublicKey};
+use bitcoin::{OutPoint, XOnlyPublicKey};
 use libp2p_identity::PeerId;
 use musig2::{PartialSignature, PubNonce};
 use serde::{de::DeserializeOwned, Serialize};
-use strata_p2p_types::OperatorPubKey;
+use strata_p2p_types::{OperatorPubKey, Scope, SessionId};
 use thiserror::Error;
 
 mod prost_serde;
@@ -97,43 +97,43 @@ where
     async fn get_partial_signatures(
         &self,
         operator_pk: &OperatorPubKey,
-        scope: sha256::Hash,
+        session_id: SessionId,
     ) -> DBResult<Option<PartialSignaturesEntry>> {
-        let key = format!("sigs-{operator_pk}_{scope}");
+        let key = format!("sigs-{operator_pk}_{session_id}");
         self.get(key).await
     }
 
     async fn set_partial_signatures_if_not_exists(
         &self,
-        scope: sha256::Hash,
+        session_id: SessionId,
         entry: PartialSignaturesEntry,
     ) -> DBResult<bool> {
-        let key = format!("sigs-{}_{scope}", entry.key);
+        let key = format!("sigs-{}_{session_id}", entry.key);
         self.set_if_not_exists(key, entry).await
     }
 
     async fn get_pub_nonces(
         &self,
         operator_pk: &OperatorPubKey,
-        scope: sha256::Hash,
+        session_id: SessionId,
     ) -> DBResult<Option<NoncesEntry>> {
-        let key = format!("nonces-{operator_pk}_{scope}");
+        let key = format!("nonces-{operator_pk}_{session_id}");
         self.get(key).await
     }
 
     async fn set_pub_nonces_if_not_exist(
         &self,
-        scope: sha256::Hash,
+        session_id: SessionId,
         entry: NoncesEntry,
     ) -> DBResult<bool> {
-        let key = format!("nonces-{}_{scope}", entry.key);
+        let key = format!("nonces-{}_{session_id}", entry.key);
         self.set_if_not_exists(key, entry).await
     }
 
     async fn get_deposit_setup(
         &self,
         operator_pk: &OperatorPubKey,
-        scope: sha256::Hash,
+        scope: Scope,
     ) -> DBResult<Option<DepositSetupEntry<DepositSetupPayload>>> {
         let key = format!("setup-{operator_pk}_{scope}");
         self.get(key).await
@@ -141,7 +141,7 @@ where
 
     async fn set_deposit_setup_if_not_exists(
         &self,
-        scope: sha256::Hash,
+        scope: Scope,
         setup: DepositSetupEntry<DepositSetupPayload>,
     ) -> DBResult<bool> {
         let key = format!("setup-{}_{scope}", setup.key);

--- a/crates/p2p/src/commands.rs
+++ b/crates/p2p/src/commands.rs
@@ -1,13 +1,12 @@
 //! Commands for P2P implementation from operator implementation.
 
-use bitcoin::{hashes::sha256, OutPoint, XOnlyPublicKey};
+use bitcoin::{OutPoint, XOnlyPublicKey};
 use libp2p::identity::secp256k1;
 use musig2::{PartialSignature, PubNonce};
 use prost::Message;
-use strata_p2p_types::OperatorPubKey;
+use strata_p2p_types::{OperatorPubKey, Scope, SessionId};
 use strata_p2p_wire::p2p::v1::{
-    DepositNonces, DepositSetup, DepositSigs, GenesisInfo, GetMessageRequest, GossipsubMsg,
-    GossipsubMsgDepositKind, GossipsubMsgKind,
+    DepositSetup, GenesisInfo, GetMessageRequest, GossipsubMsg, UnsignedGossipsubMsg,
 };
 
 /// Ask P2P implementation to distribute some data across network.
@@ -34,15 +33,15 @@ pub enum UnsignedPublishMessage<DepositSetupPayload> {
         checkpoint_pubkeys: Vec<XOnlyPublicKey>,
     },
     DepositSetup {
-        scope: sha256::Hash,
+        scope: Scope,
         payload: DepositSetupPayload,
     },
-    DepositNonces {
-        scope: sha256::Hash,
+    Musig2NoncesExchange {
+        session_id: SessionId,
         pub_nonces: Vec<PubNonce>,
     },
-    PartialSignatures {
-        scope: sha256::Hash,
+    Musig2SignaturesExchange {
+        session_id: SessionId,
         partial_sigs: Vec<PartialSignature>,
     },
 }
@@ -52,7 +51,7 @@ impl<DSP: Message + Clone> From<PublishMessage<DSP>> for GossipsubMsg<DSP> {
         GossipsubMsg {
             signature: value.signature,
             key: value.key,
-            kind: value.msg.into(),
+            unsigned: value.msg.into(),
         }
     }
 }
@@ -61,7 +60,7 @@ impl<DSP: Message + Default + Clone> UnsignedPublishMessage<DSP> {
     /// Sign `self` using supplied `keypair`. Returns a `Command`
     /// with resulting signature and public key from `keypair`.
     pub fn sign_secp256k1(&self, keypair: &secp256k1::Keypair) -> PublishMessage<DSP> {
-        let kind: GossipsubMsgKind<DSP> = self.clone().into();
+        let kind: UnsignedGossipsubMsg<DSP> = self.clone().into();
         let msg = kind.content();
         let signature = keypair.secret().sign(&msg);
 
@@ -73,32 +72,35 @@ impl<DSP: Message + Default + Clone> UnsignedPublishMessage<DSP> {
     }
 }
 
-impl<DSP: Message + Clone> From<UnsignedPublishMessage<DSP>> for GossipsubMsgKind<DSP> {
+impl<DSP: Message + Clone> From<UnsignedPublishMessage<DSP>> for UnsignedGossipsubMsg<DSP> {
     fn from(value: UnsignedPublishMessage<DSP>) -> Self {
         match value {
             UnsignedPublishMessage::GenesisInfo {
                 pre_stake_outpoint,
                 checkpoint_pubkeys,
-            } => GossipsubMsgKind::GenesisInfo(GenesisInfo {
+            } => UnsignedGossipsubMsg::GenesisInfo(GenesisInfo {
                 checkpoint_pubkeys,
                 pre_stake_outpoint,
             }),
-            UnsignedPublishMessage::DepositSetup { scope, payload } => GossipsubMsgKind::Deposit {
-                scope,
-                kind: GossipsubMsgDepositKind::Setup(DepositSetup { payload }),
-            },
-            UnsignedPublishMessage::DepositNonces { scope, pub_nonces } => {
-                GossipsubMsgKind::Deposit {
+            UnsignedPublishMessage::DepositSetup { scope, payload } => {
+                UnsignedGossipsubMsg::DepositSetup {
                     scope,
-                    kind: GossipsubMsgDepositKind::Nonces(DepositNonces { nonces: pub_nonces }),
+                    setup: DepositSetup { payload },
                 }
             }
-            UnsignedPublishMessage::PartialSignatures {
-                scope,
+            UnsignedPublishMessage::Musig2NoncesExchange {
+                session_id,
+                pub_nonces,
+            } => UnsignedGossipsubMsg::Musig2NoncesExchange {
+                session_id,
+                nonces: pub_nonces,
+            },
+            UnsignedPublishMessage::Musig2SignaturesExchange {
+                session_id,
                 partial_sigs,
-            } => GossipsubMsgKind::Deposit {
-                scope,
-                kind: GossipsubMsgDepositKind::Sigs(DepositSigs { partial_sigs }),
+            } => UnsignedGossipsubMsg::Musig2SignaturesExchange {
+                session_id,
+                signatures: partial_sigs,
             },
         }
     }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 hex.workspace = true
 libp2p-identity.workspace = true
 serde.workspace = true
+bitcoin.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitcoin.workspace = true
 hex.workspace = true
 libp2p-identity.workspace = true
 serde.workspace = true
-bitcoin.workspace = true

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod operator;
-pub mod scope;
-pub mod sessionid;
+mod operator;
+mod scope;
+mod sessionid;
 
 pub use operator::OperatorPubKey;
 pub use scope::Scope;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod operator;
+pub mod scope;
+pub mod sessionid;
 
 pub use operator::OperatorPubKey;
+pub use scope::Scope;
+pub use sessionid::SessionId;

--- a/crates/types/src/scope.rs
+++ b/crates/types/src/scope.rs
@@ -1,12 +1,30 @@
-use bitcoin::hashes::{sha256, Hash};
+use core::fmt;
+
+use bitcoin::{
+    consensus::{encode::Error, Decodable, Encodable},
+    hashes::{sha256, Hash},
+    io::Cursor,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct Scope(sha256::Hash);
 
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Scope {
     pub const fn hash(data: &[u8]) -> Self {
         Self(sha256::Hash::const_hash(data))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let mut cursor = Cursor::new(bytes);
+        let scope = Decodable::consensus_decode(&mut cursor)?;
+        Ok(Self(scope))
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
@@ -23,5 +41,20 @@ impl AsRef<[u8]> for Scope {
 impl From<sha256::Hash> for Scope {
     fn from(value: sha256::Hash) -> Self {
         Self(value)
+    }
+}
+
+impl Decodable for Scope {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
+        Ok(Self(sha256::Hash::consensus_decode(reader)?))
+    }
+}
+
+impl Encodable for Scope {
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, bitcoin::io::Error> {
+        self.0.consensus_encode(writer)
     }
 }

--- a/crates/types/src/scope.rs
+++ b/crates/types/src/scope.rs
@@ -1,61 +1,44 @@
 use core::fmt;
 
-use bitcoin::{
-    consensus::{encode::Error, Decodable, Encodable},
-    hashes::{sha256, Hash},
-    io::Cursor,
-};
+use bitcoin::hashes::{sha256, Hash};
 use serde::{Deserialize, Serialize};
 
 /// A unique identifier of deposit setup made by hashing unique data related to it
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
-pub struct Scope(sha256::Hash);
+pub struct Scope([u8; Scope::SIZE]);
 
 impl fmt::Display for Scope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 
 impl Scope {
-    pub const fn hash(data: &[u8]) -> Self {
-        Self(sha256::Hash::const_hash(data))
+    const SIZE: usize = 32;
+
+    /// Construct scope from preimage by hashing it.
+    pub fn hash(data: &[u8]) -> Self {
+        Self(sha256::Hash::hash(data).to_byte_array())
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut cursor = Cursor::new(bytes);
-        let scope = Decodable::consensus_decode(&mut cursor)?;
-        Ok(Self(scope))
+    /// Construct scope from array of bytes.
+    pub fn from_bytes(bytes: [u8; Self::SIZE]) -> Self {
+        Self(bytes)
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_byte_array().to_vec()
+        self.0.to_vec()
     }
 }
 
 impl AsRef<[u8]> for Scope {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_byte_array().as_ref()
+        self.0.as_ref()
     }
 }
 
 impl From<sha256::Hash> for Scope {
     fn from(value: sha256::Hash) -> Self {
-        Self(value)
-    }
-}
-
-impl Decodable for Scope {
-    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
-        Ok(Self(sha256::Hash::consensus_decode(reader)?))
-    }
-}
-
-impl Encodable for Scope {
-    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
-        &self,
-        writer: &mut W,
-    ) -> Result<usize, bitcoin::io::Error> {
-        self.0.consensus_encode(writer)
+        Self(value.to_byte_array())
     }
 }

--- a/crates/types/src/scope.rs
+++ b/crates/types/src/scope.rs
@@ -1,0 +1,27 @@
+use bitcoin::hashes::{sha256, Hash};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
+pub struct Scope(sha256::Hash);
+
+impl Scope {
+    pub const fn hash(data: &[u8]) -> Self {
+        Self(sha256::Hash::const_hash(data))
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_byte_array().to_vec()
+    }
+}
+
+impl AsRef<[u8]> for Scope {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_byte_array().as_ref()
+    }
+}
+
+impl From<sha256::Hash> for Scope {
+    fn from(value: sha256::Hash) -> Self {
+        Self(value)
+    }
+}

--- a/crates/types/src/scope.rs
+++ b/crates/types/src/scope.rs
@@ -7,6 +7,7 @@ use bitcoin::{
 };
 use serde::{Deserialize, Serialize};
 
+/// A unique identifier of deposit setup made by hashing unique data related to it
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct Scope(sha256::Hash);
 

--- a/crates/types/src/sessionid.rs
+++ b/crates/types/src/sessionid.rs
@@ -1,0 +1,27 @@
+use bitcoin::hashes::{sha256, Hash};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
+pub struct SessionId(sha256::Hash);
+
+impl SessionId {
+    pub const fn hash(data: &[u8]) -> Self {
+        Self(sha256::Hash::const_hash(data))
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_byte_array().to_vec()
+    }
+}
+
+impl AsRef<[u8]> for SessionId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_byte_array().as_ref()
+    }
+}
+
+impl From<sha256::Hash> for SessionId {
+    fn from(value: sha256::Hash) -> Self {
+        Self(value)
+    }
+}

--- a/crates/types/src/sessionid.rs
+++ b/crates/types/src/sessionid.rs
@@ -7,6 +7,8 @@ use bitcoin::{
 };
 use serde::{Deserialize, Serialize};
 
+/// A unique identifier of signatures and nonces exchange session made by
+/// hashing unique data related to it.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct SessionId(sha256::Hash);
 

--- a/crates/types/src/sessionid.rs
+++ b/crates/types/src/sessionid.rs
@@ -1,62 +1,44 @@
 use core::fmt;
 
-use bitcoin::{
-    consensus::{encode::Error, Decodable, Encodable},
-    hashes::{sha256, Hash},
-    io::Cursor,
-};
+use bitcoin::hashes::{sha256, Hash};
 use serde::{Deserialize, Serialize};
 
 /// A unique identifier of signatures and nonces exchange session made by
 /// hashing unique data related to it.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
-pub struct SessionId(sha256::Hash);
+pub struct SessionId([u8; SessionId::SIZE]);
 
 impl SessionId {
-    pub const fn hash(data: &[u8]) -> Self {
-        Self(sha256::Hash::const_hash(data))
+    const SIZE: usize = 32;
+
+    /// Construct session ID from preimage by hashing it.
+    pub fn hash(data: &[u8]) -> Self {
+        Self(sha256::Hash::const_hash(data).to_byte_array())
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut cursor = Cursor::new(bytes);
-        let session_id = Decodable::consensus_decode(&mut cursor)?;
-        Ok(Self(session_id))
+    pub fn from_bytes(bytes: [u8; Self::SIZE]) -> Self {
+        Self(bytes)
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_byte_array().to_vec()
+        self.0.to_vec()
     }
 }
 
 impl fmt::Display for SessionId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 
 impl AsRef<[u8]> for SessionId {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_byte_array().as_ref()
+        self.0.as_ref()
     }
 }
 
 impl From<sha256::Hash> for SessionId {
     fn from(value: sha256::Hash) -> Self {
-        Self(value)
-    }
-}
-
-impl Decodable for SessionId {
-    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
-        Ok(Self(sha256::Hash::consensus_decode(reader)?))
-    }
-}
-
-impl Encodable for SessionId {
-    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
-        &self,
-        writer: &mut W,
-    ) -> Result<usize, bitcoin::io::Error> {
-        self.0.consensus_encode(writer)
+        Self(value.to_byte_array())
     }
 }

--- a/crates/types/src/sessionid.rs
+++ b/crates/types/src/sessionid.rs
@@ -1,4 +1,10 @@
-use bitcoin::hashes::{sha256, Hash};
+use core::fmt;
+
+use bitcoin::{
+    consensus::{encode::Error, Decodable, Encodable},
+    hashes::{sha256, Hash},
+    io::Cursor,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
@@ -9,8 +15,20 @@ impl SessionId {
         Self(sha256::Hash::const_hash(data))
     }
 
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let mut cursor = Cursor::new(bytes);
+        let session_id = Decodable::consensus_decode(&mut cursor)?;
+        Ok(Self(session_id))
+    }
+
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_byte_array().to_vec()
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -23,5 +41,20 @@ impl AsRef<[u8]> for SessionId {
 impl From<sha256::Hash> for SessionId {
     fn from(value: sha256::Hash) -> Self {
         Self(value)
+    }
+}
+
+impl Decodable for SessionId {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
+        Ok(Self(sha256::Hash::consensus_decode(reader)?))
+    }
+}
+
+impl Encodable for SessionId {
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, bitcoin::io::Error> {
+        self.0.consensus_encode(writer)
     }
 }

--- a/crates/wire/src/p2p/v1/typed.rs
+++ b/crates/wire/src/p2p/v1/typed.rs
@@ -1,104 +1,117 @@
-use bitcoin::{
-    consensus::Decodable,
-    hashes::{sha256, Hash},
-    io::Cursor,
-    OutPoint, XOnlyPublicKey,
-};
+use bitcoin::{consensus::Decodable, hashes::Hash, io::Cursor, OutPoint, XOnlyPublicKey};
 use musig2::{PartialSignature, PubNonce};
 use prost::{DecodeError, Message};
-use strata_p2p_types::OperatorPubKey;
+use strata_p2p_types::{OperatorPubKey, Scope, SessionId};
 
 use super::proto::{
     get_message_request::Body as ProtoGetMessageRequestBody,
-    gossipsub_msg::Body as ProtoGossipsubMsgBody, DepositNoncesExchange as ProtoDepositNonces,
-    DepositRequestKey, DepositSetupExchange as ProtoDepositSetup,
-    DepositSignaturesExchange as ProtoDepositSigs, GenesisInfo as ProtoGenesisInfo,
-    GenesisRequestKey, GetMessageRequest as ProtoGetMessageRequest, GossipsubMsg as ProtoGossipMsg,
+    gossipsub_msg::Body as ProtoGossipsubMsgBody, DepositRequestKey,
+    DepositSetupExchange as ProtoDepositSetup, GenesisInfo as ProtoGenesisInfo, GenesisRequestKey,
+    GetMessageRequest as ProtoGetMessageRequest, GossipsubMsg as ProtoGossipMsg,
+    Musig2ExchangeRequestKey, Musig2NoncesExchange as ProtoMusig2NoncesExchange,
+    Musig2SignaturesExchange as ProtoMusig2SignaturesExchange,
 };
-
-#[derive(Clone, Debug)]
-pub enum GetMessageRequestExchangeKind {
-    Setup,
-    Nonces,
-    Signatures,
-}
 
 /// Typed version of "get_message_request::GetMessageRequest".
 #[derive(Clone, Debug)]
 pub enum GetMessageRequest {
-    Genesis {
+    /// Request genesis info for this operator.
+    Genesis { operator_pk: OperatorPubKey },
+
+    /// Request deposit setup info for scope and operator.
+    DepositSetup {
+        scope: Scope,
         operator_pk: OperatorPubKey,
     },
-    ExchangeSession {
-        scope: sha256::Hash,
+
+    /// Request musig2 signatures from operator and for session ID.
+    Musig2SignaturesExchange {
+        session_id: SessionId,
         operator_pk: OperatorPubKey,
-        kind: GetMessageRequestExchangeKind,
+    },
+
+    /// Request musig2 nonces from operator and for session ID.
+    Musig2NoncesExchange {
+        session_id: SessionId,
+        operator_pk: OperatorPubKey,
     },
 }
 
 impl GetMessageRequest {
-    pub fn from_msg(msg: ProtoGetMessageRequest) -> Option<GetMessageRequest> {
-        let body = msg.body?;
+    pub fn from_msg(msg: ProtoGetMessageRequest) -> Result<GetMessageRequest, DecodeError> {
+        let body = msg.body.ok_or(DecodeError::new("Message without body"))?;
 
-        let (operator_pk, deposit_txid, kind) = match body {
+        let request = match body {
             ProtoGetMessageRequestBody::DepositSetup(DepositRequestKey { scope, operator }) => {
-                (scope, operator, GetMessageRequestExchangeKind::Setup)
+                let scope =
+                    Scope::from_bytes(&scope).map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::DepositSetup {
+                    scope,
+                    operator_pk: operator.into(),
+                }
             }
-            ProtoGetMessageRequestBody::DepositNonce(DepositRequestKey { scope, operator }) => {
-                (scope, operator, GetMessageRequestExchangeKind::Nonces)
+            ProtoGetMessageRequestBody::Nonces(Musig2ExchangeRequestKey {
+                session_id,
+                operator,
+            }) => {
+                let session_id = SessionId::from_bytes(&session_id)
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::Musig2NoncesExchange {
+                    session_id,
+                    operator_pk: operator.into(),
+                }
             }
-            ProtoGetMessageRequestBody::DepositSigs(DepositRequestKey { scope, operator }) => {
-                (scope, operator, GetMessageRequestExchangeKind::Signatures)
+            ProtoGetMessageRequestBody::Sigs(Musig2ExchangeRequestKey {
+                session_id,
+                operator,
+            }) => {
+                let session_id = SessionId::from_bytes(&session_id)
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::Musig2SignaturesExchange {
+                    session_id,
+                    operator_pk: operator.into(),
+                }
             }
             ProtoGetMessageRequestBody::GenesisInfo(GenesisRequestKey { operator }) => {
-                return Some(Self::Genesis {
-                    operator_pk: OperatorPubKey::from(operator),
-                });
+                Self::Genesis {
+                    operator_pk: operator.into(),
+                }
             }
         };
 
-        let operator_pk = OperatorPubKey::from(operator_pk);
-        let mut cur = Cursor::new(deposit_txid);
-        let scope = Decodable::consensus_decode(&mut cur).ok()?;
-
-        Some(Self::ExchangeSession {
-            scope,
-            operator_pk,
-            kind,
-        })
+        Ok(request)
     }
 
     pub fn into_msg(self) -> ProtoGetMessageRequest {
         let body = match self {
-            GetMessageRequest::Genesis { operator_pk } => {
+            Self::Genesis { operator_pk } => {
                 ProtoGetMessageRequestBody::GenesisInfo(GenesisRequestKey {
                     operator: operator_pk.into(),
                 })
             }
-            GetMessageRequest::ExchangeSession {
-                scope,
+            Self::DepositSetup { scope, operator_pk } => {
+                ProtoGetMessageRequestBody::DepositSetup(DepositRequestKey {
+                    scope: scope.to_vec(),
+                    operator: operator_pk.into(),
+                })
+            }
+            Self::Musig2SignaturesExchange {
+                session_id,
                 operator_pk,
-                kind,
-            } => match kind {
-                GetMessageRequestExchangeKind::Setup => {
-                    ProtoGetMessageRequestBody::DepositSetup(DepositRequestKey {
-                        scope: scope.to_byte_array().to_vec(),
-                        operator: operator_pk.into(),
-                    })
-                }
-                GetMessageRequestExchangeKind::Nonces => {
-                    ProtoGetMessageRequestBody::DepositNonce(DepositRequestKey {
-                        scope: scope.to_byte_array().to_vec(),
-                        operator: operator_pk.into(),
-                    })
-                }
-                GetMessageRequestExchangeKind::Signatures => {
-                    ProtoGetMessageRequestBody::DepositSigs(DepositRequestKey {
-                        scope: scope.to_byte_array().to_vec(),
-                        operator: operator_pk.into(),
-                    })
-                }
-            },
+            } => ProtoGetMessageRequestBody::Nonces(Musig2ExchangeRequestKey {
+                session_id: session_id.to_vec(),
+                operator: operator_pk.into(),
+            }),
+            Self::Musig2NoncesExchange {
+                session_id,
+                operator_pk,
+            } => ProtoGetMessageRequestBody::Sigs(Musig2ExchangeRequestKey {
+                session_id: session_id.to_vec(),
+                operator: operator_pk.into(),
+            }),
         };
 
         ProtoGetMessageRequest { body: Some(body) }
@@ -106,9 +119,10 @@ impl GetMessageRequest {
 
     pub fn operator_pubkey(&self) -> &OperatorPubKey {
         match self {
-            Self::Genesis { operator_pk } | Self::ExchangeSession { operator_pk, .. } => {
-                operator_pk
-            }
+            Self::Genesis { operator_pk }
+            | Self::DepositSetup { operator_pk, .. }
+            | Self::Musig2NoncesExchange { operator_pk, .. }
+            | Self::Musig2SignaturesExchange { operator_pk, .. } => operator_pk,
         }
     }
 }
@@ -126,44 +140,6 @@ impl<DSP: Message + Default> DepositSetup<DSP> {
         let payload: DSP = Message::decode(proto.payload.as_ref())?;
 
         Ok(Self { payload })
-    }
-}
-
-/// Operators exchange nonces before signing.
-#[derive(Debug, Clone)]
-pub struct DepositNonces {
-    pub nonces: Vec<PubNonce>,
-}
-
-impl DepositNonces {
-    pub fn from_proto_msg(proto: &ProtoDepositNonces) -> Result<Self, DecodeError> {
-        let pub_nonces = proto
-            .pub_nonces
-            .iter()
-            .map(|bytes| PubNonce::from_bytes(bytes))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| DecodeError::new(err.to_string()))?;
-
-        Ok(Self { nonces: pub_nonces })
-    }
-}
-
-/// Operators exchange signatures for transaction graph.
-#[derive(Debug, Clone)]
-pub struct DepositSigs {
-    pub partial_sigs: Vec<PartialSignature>,
-}
-
-impl DepositSigs {
-    pub fn from_proto_msg(proto: &ProtoDepositSigs) -> Result<Self, DecodeError> {
-        let partial_sigs = proto
-            .partial_sigs
-            .iter()
-            .map(|bytes| PartialSignature::from_slice(bytes))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| DecodeError::new(err.to_string()))?;
-
-        Ok(Self { partial_sigs })
     }
 }
 
@@ -197,72 +173,74 @@ impl GenesisInfo {
 }
 
 #[derive(Clone, Debug)]
-pub enum GossipsubMsgDepositKind<DepositSetupPayload: Message> {
-    /// New deposit request appeared, and operators
-    /// exchanging setup data.
-    Setup(DepositSetup<DepositSetupPayload>),
-    /// Operators exchange nonces before signing.
-    Nonces(DepositNonces),
-    /// Operators exchange signatures for transaction graph.
-    Sigs(DepositSigs),
-}
-
-impl<DepositSetupPayload: Message> From<DepositSigs>
-    for GossipsubMsgDepositKind<DepositSetupPayload>
-{
-    fn from(v: DepositSigs) -> Self {
-        Self::Sigs(v)
-    }
-}
-
-impl<DepositSetupPayload: Message> From<DepositNonces>
-    for GossipsubMsgDepositKind<DepositSetupPayload>
-{
-    fn from(v: DepositNonces) -> Self {
-        Self::Nonces(v)
-    }
-}
-
-impl<DepositSetupPayload: Message> From<DepositSetup<DepositSetupPayload>>
-    for GossipsubMsgDepositKind<DepositSetupPayload>
-{
-    fn from(v: DepositSetup<DepositSetupPayload>) -> Self {
-        Self::Setup(v)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub enum GossipsubMsgKind<DepositSetupPayload: Message> {
+pub enum UnsignedGossipsubMsg<DepositSetupPayload: Message> {
     /// Operators exchange
     GenesisInfo(GenesisInfo),
-    Deposit {
-        scope: sha256::Hash,
-        kind: GossipsubMsgDepositKind<DepositSetupPayload>,
+    /// New deposit request appeared, and operators
+    /// exchanging setup data.
+    DepositSetup {
+        scope: Scope,
+        setup: DepositSetup<DepositSetupPayload>,
+    },
+    /// Operators exchange nonces before signing.
+    Musig2NoncesExchange {
+        session_id: SessionId,
+        nonces: Vec<PubNonce>,
+    },
+    /// Operators exchange signatures for transaction graph.
+    Musig2SignaturesExchange {
+        session_id: SessionId,
+        signatures: Vec<PartialSignature>,
     },
 }
 
-impl<DSP: Message + Default> GossipsubMsgKind<DSP> {
+impl<DSP: Message + Default> UnsignedGossipsubMsg<DSP> {
     pub fn from_msg_proto(proto: &ProtoGossipsubMsgBody) -> Result<Self, DecodeError> {
-        let (scope, kind) = match proto {
+        let unsigned = match proto {
             ProtoGossipsubMsgBody::GenesisInfo(proto) => {
-                return Ok(Self::GenesisInfo(GenesisInfo::from_proto_msg(proto)?));
+                Self::GenesisInfo(GenesisInfo::from_proto_msg(proto)?)
             }
             ProtoGossipsubMsgBody::Setup(proto) => {
-                (&proto.scope, DepositSetup::from_proto_msg(proto)?.into())
+                let scope = Scope::from_bytes(&proto.scope)
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::DepositSetup {
+                    scope,
+                    setup: DepositSetup::from_proto_msg(proto)?,
+                }
             }
             ProtoGossipsubMsgBody::Nonce(proto) => {
-                (&proto.scope, DepositNonces::from_proto_msg(proto)?.into())
+                let session_id = SessionId::from_bytes(&proto.session_id)
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                let nonces = proto
+                    .pub_nonces
+                    .iter()
+                    .map(|bytes| PubNonce::from_bytes(bytes))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::Musig2NoncesExchange { session_id, nonces }
             }
             ProtoGossipsubMsgBody::Sigs(proto) => {
-                (&proto.scope, DepositSigs::from_proto_msg(proto)?.into())
+                let session_id = SessionId::from_bytes(&proto.session_id)
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                let partial_sigs = proto
+                    .partial_sigs
+                    .iter()
+                    .map(|bytes| PartialSignature::from_slice(bytes))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|err| DecodeError::new(err.to_string()))?;
+
+                Self::Musig2SignaturesExchange {
+                    session_id,
+                    signatures: partial_sigs,
+                }
             }
         };
 
-        let mut curr = Cursor::new(scope);
-        let scope = Decodable::consensus_decode(&mut curr)
-            .map_err(|err| DecodeError::new(err.to_string()))?;
-
-        Ok(Self::Deposit { scope, kind })
+        Ok(unsigned)
     }
 
     /// Return content of the message for signing.
@@ -273,7 +251,7 @@ impl<DSP: Message + Default> GossipsubMsgKind<DSP> {
         let mut content = Vec::new();
 
         match &self {
-            GossipsubMsgKind::GenesisInfo(GenesisInfo {
+            Self::GenesisInfo(GenesisInfo {
                 pre_stake_outpoint,
                 checkpoint_pubkeys,
             }) => {
@@ -283,24 +261,24 @@ impl<DSP: Message + Default> GossipsubMsgKind<DSP> {
                     content.extend(key.serialize());
                 });
             }
-            GossipsubMsgKind::Deposit { scope, kind } => {
-                content.extend(scope.to_byte_array());
-
-                match kind {
-                    GossipsubMsgDepositKind::Setup(DepositSetup { payload }) => {
-                        content.extend(payload.encode_to_vec());
-                    }
-                    GossipsubMsgDepositKind::Nonces(DepositNonces { nonces }) => {
-                        for nonce in nonces {
-                            content.extend(nonce.serialize());
-                        }
-                    }
-                    GossipsubMsgDepositKind::Sigs(DepositSigs { partial_sigs }) => {
-                        for sig in partial_sigs {
-                            content.extend(sig.serialize());
-                        }
-                    }
-                };
+            Self::DepositSetup { scope, setup } => {
+                content.extend(scope.as_ref());
+                content.extend(setup.payload.encode_to_vec());
+            }
+            Self::Musig2NoncesExchange { session_id, nonces } => {
+                content.extend(session_id.as_ref());
+                for nonce in nonces {
+                    content.extend(nonce.serialize());
+                }
+            }
+            Self::Musig2SignaturesExchange {
+                session_id,
+                signatures,
+            } => {
+                content.extend(session_id.as_ref());
+                for sig in signatures {
+                    content.extend(sig.serialize());
+                }
             }
         };
 
@@ -309,44 +287,34 @@ impl<DSP: Message + Default> GossipsubMsgKind<DSP> {
 
     fn to_raw(&self) -> ProtoGossipsubMsgBody {
         match self {
-            GossipsubMsgKind::GenesisInfo(info) => {
-                ProtoGossipsubMsgBody::GenesisInfo(ProtoGenesisInfo {
-                    pre_stake_vout: info.pre_stake_outpoint.vout,
-                    pre_stake_txid: info.pre_stake_outpoint.txid.to_byte_array().to_vec(),
-                    checkpoint_pubkeys: info
-                        .checkpoint_pubkeys
-                        .iter()
-                        .map(|k| k.serialize().to_vec())
-                        .collect(),
+            Self::GenesisInfo(info) => ProtoGossipsubMsgBody::GenesisInfo(ProtoGenesisInfo {
+                pre_stake_vout: info.pre_stake_outpoint.vout,
+                pre_stake_txid: info.pre_stake_outpoint.txid.to_byte_array().to_vec(),
+                checkpoint_pubkeys: info
+                    .checkpoint_pubkeys
+                    .iter()
+                    .map(|k| k.serialize().to_vec())
+                    .collect(),
+            }),
+            Self::DepositSetup { scope, setup } => {
+                ProtoGossipsubMsgBody::Setup(ProtoDepositSetup {
+                    scope: scope.to_vec(),
+                    payload: setup.payload.encode_to_vec(),
                 })
             }
-            GossipsubMsgKind::Deposit { scope, kind } => {
-                let scope = scope.to_byte_array().to_vec();
-                match kind {
-                    GossipsubMsgDepositKind::Setup(setup) => {
-                        ProtoGossipsubMsgBody::Setup(ProtoDepositSetup {
-                            scope,
-                            payload: setup.payload.encode_to_vec(),
-                        })
-                    }
-                    GossipsubMsgDepositKind::Nonces(dep) => {
-                        ProtoGossipsubMsgBody::Nonce(ProtoDepositNonces {
-                            scope,
-                            pub_nonces: dep.nonces.iter().map(|n| n.serialize().to_vec()).collect(),
-                        })
-                    }
-                    GossipsubMsgDepositKind::Sigs(dep) => {
-                        ProtoGossipsubMsgBody::Sigs(ProtoDepositSigs {
-                            scope,
-                            partial_sigs: dep
-                                .partial_sigs
-                                .iter()
-                                .map(|s| s.serialize().to_vec())
-                                .collect(),
-                        })
-                    }
-                }
+            Self::Musig2NoncesExchange { session_id, nonces } => {
+                ProtoGossipsubMsgBody::Nonce(ProtoMusig2NoncesExchange {
+                    session_id: session_id.to_vec(),
+                    pub_nonces: nonces.iter().map(|n| n.serialize().to_vec()).collect(),
+                })
             }
+            Self::Musig2SignaturesExchange {
+                session_id,
+                signatures,
+            } => ProtoGossipsubMsgBody::Sigs(ProtoMusig2SignaturesExchange {
+                session_id: session_id.to_vec(),
+                partial_sigs: signatures.iter().map(|s| s.serialize().to_vec()).collect(),
+            }),
         }
     }
 }
@@ -355,7 +323,7 @@ impl<DSP: Message + Default> GossipsubMsgKind<DSP> {
 pub struct GossipsubMsg<DepositSetupPayload: Message + Clone> {
     pub signature: Vec<u8>,
     pub key: OperatorPubKey,
-    pub kind: GossipsubMsgKind<DepositSetupPayload>,
+    pub unsigned: UnsignedGossipsubMsg<DepositSetupPayload>,
 }
 
 impl<DepositSetupPayload> GossipsubMsg<DepositSetupPayload>
@@ -368,13 +336,13 @@ where
             return Err(DecodeError::new("Message with empty body"));
         };
 
-        let kind = GossipsubMsgKind::<DepositSetupPayload>::from_msg_proto(&body)?;
+        let kind = UnsignedGossipsubMsg::<DepositSetupPayload>::from_msg_proto(&body)?;
         let key = msg.key.into();
 
         Ok(Self {
             signature: msg.signature,
             key,
-            kind,
+            unsigned: kind,
         })
     }
 
@@ -382,7 +350,7 @@ where
         Ok(Self {
             signature: msg.signature,
             key: msg.key.into(),
-            kind: GossipsubMsgKind::from_msg_proto(&msg.body.unwrap())?,
+            unsigned: UnsignedGossipsubMsg::from_msg_proto(&msg.body.unwrap())?,
         })
     }
 
@@ -390,11 +358,11 @@ where
         ProtoGossipMsg {
             key: self.key.into(),
             signature: self.signature,
-            body: Some(self.kind.to_raw()),
+            body: Some(self.unsigned.to_raw()),
         }
     }
 
     pub fn content(&self) -> Vec<u8> {
-        self.kind.content()
+        self.unsigned.content()
     }
 }

--- a/proto/strata/bitvm2/p2p/v1/getmessage.proto
+++ b/proto/strata/bitvm2/p2p/v1/getmessage.proto
@@ -5,19 +5,29 @@ package strata.bitvm2.p2p.v1;
 import "strata/bitvm2/p2p/v1/gossipsub.proto";
 
 message DepositRequestKey {
+  // 32-byte hash
   bytes scope = 1;
+  // Public key of target operator.
+  bytes operator = 2;
+}
+
+message Musig2ExchangeRequestKey {
+  // 32-byte hash
+  bytes session_id = 1;
+  // Public key of target operator.
   bytes operator = 2;
 }
 
 message GenesisRequestKey {
+  // Public key of target operator.
   bytes operator = 1;
 }
 
 message GetMessageRequest {
   oneof body {
     DepositRequestKey deposit_setup = 1;
-    DepositRequestKey deposit_nonce = 2;
-    DepositRequestKey deposit_sigs = 3;
+    Musig2ExchangeRequestKey nonces = 2;
+    Musig2ExchangeRequestKey sigs = 3;
     GenesisRequestKey genesis_info = 4;
   }
 }

--- a/proto/strata/bitvm2/p2p/v1/gossipsub.proto
+++ b/proto/strata/bitvm2/p2p/v1/gossipsub.proto
@@ -18,16 +18,16 @@ message DepositSetupExchange {
   bytes payload = 2;
 }
 
-message DepositNoncesExchange {
+message Musig2NoncesExchange {
   // 32-byte hash of some unique to deposit data
-  bytes scope = 1;
+  bytes session_id = 1;
   // Public nonces for each transaction
   repeated bytes pub_nonces = 2;
 }
 
-message DepositSignaturesExchange {
+message Musig2SignaturesExchange {
   // 32-byte hash of some unique to deposit data
-  bytes scope = 1;
+  bytes session_id = 1;
   // Partial signatures for each transaction
   repeated bytes partial_sigs = 2;
 }
@@ -36,8 +36,8 @@ message GossipsubMsg {
   oneof body {
     GenesisInfo genesis_info = 1;
     DepositSetupExchange setup = 2;
-    DepositNoncesExchange nonce = 3;
-    DepositSignaturesExchange sigs = 4;
+    Musig2NoncesExchange nonce = 3;
+    Musig2SignaturesExchange sigs = 4;
   }
   // Public key of the operator used for P2P message signing only.
   bytes key = 10;


### PR DESCRIPTION
## Description

Introduce newtypes `SessionId` and `Scope` and use them in nonces, signatures and setup messages instead of hash. Rename `Deposit{Sigs,Signatures,ExhangeSignatures}` to `Musig2SignaturesExchange`, the same for nonces.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This changes were made after comments from #4 about scopes usage and suggestions to rename some parts of the code.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
