### PR TITLE
Add `CleanStorage` command for P2P

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -2547,7 +2556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3155,6 +3164,7 @@ dependencies = [
  "async-trait",
  "bitcoin",
  "futures",
+ "itertools 0.14.0",
  "libp2p",
  "musig2",
  "prost",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { workspace = true, features = ["macros", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
 
+itertools = "0.14.0"
 strata-p2p-db.path = "../db"
 strata-p2p-types.path = "../types"
 strata-p2p-wire.path = "../wire"

--- a/crates/p2p/src/commands.rs
+++ b/crates/p2p/src/commands.rs
@@ -17,6 +17,9 @@ pub enum Command<DepositSetupPayload> {
 
     /// Request some message directly from other operator by peer id.
     RequestMessage(GetMessageRequest),
+
+    /// Clean session, scopes from internal DB.
+    CleanStorage(CleanStorageCommand),
 }
 
 #[derive(Debug, Clone)]
@@ -111,5 +114,55 @@ impl<DepositSetupPayload> From<PublishMessage<DepositSetupPayload>>
 {
     fn from(v: PublishMessage<DepositSetupPayload>) -> Self {
         Self::PublishMessage(v)
+    }
+}
+
+/// Command P2P to clean entries from internal key-value storage by
+/// session IDs, scopes and operator pubkeys.
+#[derive(Debug, Clone)]
+pub struct CleanStorageCommand {
+    pub scopes: Vec<Scope>,
+    pub session_ids: Vec<SessionId>,
+    pub operators: Vec<OperatorPubKey>,
+}
+
+impl CleanStorageCommand {
+    pub const fn new(
+        scopes: Vec<Scope>,
+        session_ids: Vec<SessionId>,
+        operators: Vec<OperatorPubKey>,
+    ) -> Self {
+        Self {
+            scopes,
+            session_ids,
+            operators,
+        }
+    }
+
+    /// Clean entries only by scope and operators from storage.
+    pub const fn with_scopes(scopes: Vec<Scope>, operators: Vec<OperatorPubKey>) -> Self {
+        Self {
+            scopes,
+            session_ids: Vec::new(),
+            operators,
+        }
+    }
+
+    /// Clean entries only by session IDs and operators from storage.
+    pub const fn with_session_ids(
+        session_ids: Vec<SessionId>,
+        operators: Vec<OperatorPubKey>,
+    ) -> Self {
+        Self {
+            scopes: Vec::new(),
+            session_ids,
+            operators,
+        }
+    }
+}
+
+impl<DSP> From<CleanStorageCommand> for Command<DSP> {
+    fn from(v: CleanStorageCommand) -> Self {
+        Self::CleanStorage(v)
     }
 }

--- a/crates/p2p/src/swarm/handle.rs
+++ b/crates/p2p/src/swarm/handle.rs
@@ -31,8 +31,8 @@ where
     }
 
     /// Send command to P2P.
-    pub async fn send_command(&self, command: Command<DSP>) {
-        let _ = self.commands.send(command).await;
+    pub async fn send_command(&self, command: impl Into<Command<DSP>>) {
+        let _ = self.commands.send(command.into()).await;
     }
 
     /// Get next event from P2P from events channel.

--- a/crates/p2p/tests/gossipsub.rs
+++ b/crates/p2p/tests/gossipsub.rs
@@ -8,7 +8,7 @@ use libp2p::{
     PeerId,
 };
 use strata_p2p::{
-    commands::{Command, UnsignedPublishMessage},
+    commands::{CleanStorageCommand, Command, UnsignedPublishMessage},
     events::Event,
     swarm::handle::P2PHandle,
 };
@@ -263,6 +263,71 @@ async fn test_all_to_all_multiple_scopes() -> anyhow::Result<()> {
     cancel.cancel();
 
     tasks.wait().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_operator_cleans_entries_correctly_at_command() -> anyhow::Result<()> {
+    const OPERATORS_NUM: usize = 2;
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let Setup {
+        mut operators,
+        cancel,
+        tasks,
+    } = Setup::all_to_all(OPERATORS_NUM).await?;
+
+    let scope = Scope::hash(b"scope");
+    let session_id = SessionId::hash(b"session_id");
+
+    exchange_genesis_info(&mut operators, OPERATORS_NUM).await?;
+    exchange_deposit_setup(&mut operators, OPERATORS_NUM, scope).await?;
+    exchange_deposit_nonces(&mut operators, OPERATORS_NUM, session_id).await?;
+    exchange_deposit_sigs(&mut operators, OPERATORS_NUM, session_id).await?;
+
+    let other_operator_pubkey = OperatorPubKey::from(operators[0].kp.public().to_bytes().to_vec());
+    let last_operator = &mut operators[1];
+    last_operator
+        .handle
+        .send_command(CleanStorageCommand::new(
+            vec![scope],
+            vec![session_id],
+            vec![other_operator_pubkey.clone()],
+        ))
+        .await;
+
+    cancel.cancel();
+    tasks.wait().await;
+
+    // Check that storage is empty after that.
+    let setup_entry = <AsyncDB as RepositoryExt<()>>::get_deposit_setup(
+        &last_operator.db,
+        &other_operator_pubkey,
+        scope,
+    )
+    .await?;
+    assert!(setup_entry.is_none());
+
+    let nonces_entry = <AsyncDB as RepositoryExt<()>>::get_pub_nonces(
+        &last_operator.db,
+        &other_operator_pubkey,
+        session_id,
+    )
+    .await?;
+    assert!(nonces_entry.is_none());
+
+    let sigs_entry = <AsyncDB as RepositoryExt<()>>::get_partial_signatures(
+        &last_operator.db,
+        &other_operator_pubkey,
+        session_id,
+    )
+    .await?;
+    assert!(sigs_entry.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
`CleanStorageCommand` - deletes all entries from storage by session IDs, scopes, and operators' pubkeys.

For that `delete_raw` method for `Repository` was added, which deletes entries at once by an array of keys.

Implementation creates cartesian products from sets of operators' pubkeys and session IDs, operators' pubkeys and scopes, then deletes all entries at once, but sequentially for each type of entry (nonces, signatures or deposit setups).


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This branch is based on `refactor/session-id...` as this change requires `Scope` and `SessionId` types to be presented.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
