### PR TITLE
fix!: redundant Exchange in getmessage

### DIFF
--- a/crates/wire/src/p2p/v1/typed.rs
+++ b/crates/wire/src/p2p/v1/typed.rs
@@ -17,9 +17,8 @@ use super::proto::{
     get_message_request::Body as ProtoGetMessageRequestBody,
     gossipsub_msg::Body as ProtoGossipsubMsgBody, DepositRequestKey,
     DepositSetupExchange as ProtoDepositSetup, GetMessageRequest as ProtoGetMessageRequest,
-    GossipsubMsg as ProtoGossipMsg, Musig2ExchangeRequestKey,
-    Musig2NoncesExchange as ProtoMusig2NoncesExchange,
-    Musig2SignaturesExchange as ProtoMusig2SignaturesExchange,
+    GossipsubMsg as ProtoGossipMsg, Musig2NoncesExchange as ProtoMusig2NoncesExchange,
+    Musig2RequestKey, Musig2SignaturesExchange as ProtoMusig2SignaturesExchange,
     StakeChainExchange as ProtoStakeChainExchange, StakeChainRequestKey,
 };
 
@@ -71,7 +70,7 @@ impl GetMessageRequest {
                     operator_pk: operator.into(),
                 }
             }
-            ProtoGetMessageRequestBody::Nonces(Musig2ExchangeRequestKey {
+            ProtoGetMessageRequestBody::Nonces(Musig2RequestKey {
                 session_id,
                 operator,
             }) => {
@@ -85,7 +84,7 @@ impl GetMessageRequest {
                     operator_pk: operator.into(),
                 }
             }
-            ProtoGetMessageRequestBody::Sigs(Musig2ExchangeRequestKey {
+            ProtoGetMessageRequestBody::Sigs(Musig2RequestKey {
                 session_id,
                 operator,
             }) => {
@@ -136,14 +135,14 @@ impl GetMessageRequest {
             Self::Musig2SignaturesExchange {
                 session_id,
                 operator_pk,
-            } => ProtoGetMessageRequestBody::Nonces(Musig2ExchangeRequestKey {
+            } => ProtoGetMessageRequestBody::Nonces(Musig2RequestKey {
                 session_id: session_id.to_vec(),
                 operator: operator_pk.into(),
             }),
             Self::Musig2NoncesExchange {
                 session_id,
                 operator_pk,
-            } => ProtoGetMessageRequestBody::Sigs(Musig2ExchangeRequestKey {
+            } => ProtoGetMessageRequestBody::Sigs(Musig2RequestKey {
                 session_id: session_id.to_vec(),
                 operator: operator_pk.into(),
             }),

--- a/proto/strata/bitvm2/p2p/v1/getmessage.proto
+++ b/proto/strata/bitvm2/p2p/v1/getmessage.proto
@@ -13,7 +13,7 @@ message DepositRequestKey {
 }
 
 // Request for Musig2 (public) nonces or (partial) signatures.
-message Musig2ExchangeRequestKey {
+message Musig2RequestKey {
   // 32-byte hash of the deposit data.
   bytes session_id = 1;
   // Public key of target operator.
@@ -32,8 +32,8 @@ message StakeChainRequestKey {
 message GetMessageRequest {
   oneof body {
     DepositRequestKey deposit_setup = 1;
-    Musig2ExchangeRequestKey nonces = 2;
-    Musig2ExchangeRequestKey sigs = 3;
+    Musig2RequestKey nonces = 2;
+    Musig2RequestKey sigs = 3;
     StakeChainRequestKey stake_chain = 4;
   }
 }


### PR DESCRIPTION
## Description

Removes redundant `Exchange` in get messages.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
