### PR TITLE
feat(handle): `is_connected` command

### DIFF
--- a/crates/p2p/src/tests/is_connected.rs
+++ b/crates/p2p/src/tests/is_connected.rs
@@ -1,0 +1,27 @@
+//! Tests for the `is_connected` method.
+
+use crate::tests::common::Setup;
+
+#[tokio::test]
+async fn test_is_connected() -> anyhow::Result<()> {
+    // Set up two connected operators
+    let Setup {
+        operators,
+        cancel,
+        tasks,
+    } = Setup::all_to_all(2).await?;
+
+    // Verify operator 0 is connected to operator 1
+    let is_connected = operators[0].handle.is_connected(operators[1].peer_id).await;
+    assert!(is_connected);
+
+    // Also test the get_connected_peers API
+    let connected_peers = operators[0].handle.get_connected_peers().await;
+    assert!(connected_peers.contains(&operators[1].peer_id));
+
+    // Cleanup
+    cancel.cancel();
+    tasks.wait().await;
+
+    Ok(())
+}

--- a/crates/p2p/src/tests/mod.rs
+++ b/crates/p2p/src/tests/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod common;
 pub(crate) mod connect_peer;
 pub(crate) mod db;
 pub(crate) mod gossipsub;
+pub(crate) mod is_connected;
 pub(crate) mod request;


### PR DESCRIPTION
## Description

Adds a `is_connected` command to the `P2PHandle`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I am using `tokio`'s `oneshot` channel to avoid the `QueryP2PState` command to clog the `Event` channel, since we would have to pop events (and risk poping something that was not processed yet) until we see the result from the `QueryP2PState` and send back to the user.

With this caveat we had to gave up `Clone` on `Command` since `oneshot` channels are not `Clone` but that is not an issue.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Relates to the "is peer online" in the strata-bridge node P2P functionality.
