### PR TITLE
feat: add WOTS 128 (32 + 4) message length support

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -16,4 +16,4 @@ pub use operator::P2POperatorPubKey;
 pub use scope::Scope;
 pub use session_id::SessionId;
 pub use stake_chain_id::StakeChainId;
-pub use wots::{Wots160PublicKey, Wots256PublicKey, WOTS_SINGLE};
+pub use wots::{Wots128PublicKey, Wots160PublicKey, Wots256PublicKey, WOTS_SINGLE};


### PR DESCRIPTION
## Description

Adds support for the Winternitz one-time signature (WOTS) for 16 bytes (128-bit) with 4 bytes as checksum (36-byte message length) and replaces the 20 bytes (160-bit, 44-byte message length) as the hashes in the Groth16 Public Keys. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I am still keeping the 160 around...

Also adding ALL THE TESTS for the 128 and updating documentation and doctests.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None.
