### PR TITLE
feat: adjust the max message size for Gossip to 500kb

### DIFF
--- a/crates/p2p/src/swarm/behavior.rs
+++ b/crates/p2p/src/swarm/behavior.rs
@@ -18,7 +18,7 @@ use libp2p::{
 };
 use strata_p2p_wire::p2p::v1::proto::{GetMessageRequest, GetMessageResponse};
 
-use super::{codec, TOPIC};
+use super::{codec, MAX_TRANSMIT_SIZE, TOPIC};
 
 /// Alias for request-response behaviour with messages serialized by using
 /// homebrewed codec implementation.
@@ -66,6 +66,7 @@ impl Behaviour {
                 gossipsub::ConfigBuilder::default()
                     .validation_mode(gossipsub::ValidationMode::Permissive)
                     .validate_messages()
+                    .max_transmit_size(MAX_TRANSMIT_SIZE)
                     .build()
                     .expect("gossipsub config at this stage must be valid"),
                 None,

--- a/crates/p2p/src/swarm/mod.rs
+++ b/crates/p2p/src/swarm/mod.rs
@@ -45,6 +45,9 @@ pub mod handle;
 // TODO(Velnbur): make this configurable later
 static TOPIC: LazyLock<Sha256Topic> = LazyLock::new(|| Sha256Topic::new("bitvm2"));
 
+/// Global MAX_TRANSMIT_SIZE for gossipsub messages.
+const MAX_TRANSMIT_SIZE: usize = 512 * 1024;
+
 /// Global name of the protocol
 // TODO(Velnbur): make this configurable later
 const PROTOCOL_NAME: &str = "/strata-bitvm2";

--- a/crates/wire/src/p2p/v1/typed.rs
+++ b/crates/wire/src/p2p/v1/typed.rs
@@ -190,8 +190,6 @@ impl GetMessageRequest {
 
 /// New deposit request appeared, and operators exchanging setup data.
 #[derive(Debug, Clone)]
-#[expect(clippy::large_enum_variant)]
-#[allow(unfulfilled_lint_expectations)]
 pub struct DepositSetup {
     /// [`sha256::Hash`] hash of the stake transaction that the preimage is revealed when advancing
     /// the stake.


### PR DESCRIPTION
## Description

Adjust the max message size for Gossip from the default 2kb to 500kb because of WOTS huge keys.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Needed for strata-bridge

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
