### PR TITLE
Bad Signature on Real-world sized Deposit Setup messages

### DIFF
--- a/crates/p2p/src/swarm/mod.rs
+++ b/crates/p2p/src/swarm/mod.rs
@@ -118,10 +118,9 @@ impl P2P {
 
         let keypair = cfg.keypair.clone();
 
-        // WOTS PKs are biiiiiiiig
-        let channel_size = channel_size.unwrap_or(400_000);
+        let channel_size = channel_size.unwrap_or(256);
         let (events_tx, events_rx) = broadcast::channel(channel_size);
-        let (cmds_tx, cmds_rx) = mpsc::channel(50_000);
+        let (cmds_tx, cmds_rx) = mpsc::channel(64);
 
         Ok((
             Self {

--- a/crates/p2p/src/tests/message_size.rs
+++ b/crates/p2p/src/tests/message_size.rs
@@ -17,14 +17,18 @@ use crate::{
     tests::common::Setup,
 };
 
+const N_PUBLIC_INPUTS: usize = 1;
+const N_FIELD_ELEMENTS: usize = 14;
+const N_HASHES: usize = 363;
+
 fn real_deposit_setup() -> anyhow::Result<UnsignedPublishMessage> {
     let scope = Scope::hash(b"scope");
     let wots_pks = WotsPublicKeys {
         withdrawal_fulfillment: Wots256PublicKey::from_flattened_bytes(&[1u8; 68 * 20]),
         groth16: Groth16PublicKeys::new(
-            vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20])],
-            vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); 14],
-            vec![Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]); 363],
+            vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20]); N_PUBLIC_INPUTS],
+            vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); N_FIELD_ELEMENTS],
+            vec![Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]); N_HASHES],
         ),
     };
     Ok(UnsignedPublishMessage::DepositSetup {

--- a/crates/p2p/src/tests/message_size.rs
+++ b/crates/p2p/src/tests/message_size.rs
@@ -1,0 +1,85 @@
+//! Test the size of messages in the p2p gossipsub protocol using the [`DepositSetup`] message.
+
+use anyhow::bail;
+use bitcoin::{
+    hashes::{sha256, Hash},
+    Txid, XOnlyPublicKey,
+};
+use strata_p2p_types::{
+    Groth16PublicKeys, Scope, Wots128PublicKey, Wots256PublicKey, WotsPublicKeys,
+};
+use strata_p2p_wire::p2p::v1::{GossipsubMsg, UnsignedGossipsubMsg};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+use crate::{
+    commands::{Command, UnsignedPublishMessage},
+    events::Event,
+    tests::common::Setup,
+};
+
+fn real_deposit_setup() -> anyhow::Result<UnsignedPublishMessage> {
+    let scope = Scope::hash(b"scope");
+    let wots_pks = WotsPublicKeys {
+        withdrawal_fulfillment: Wots256PublicKey::from_flattened_bytes(&[1u8; 68 * 20]),
+        groth16: Groth16PublicKeys::new(
+            vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20])],
+            vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); 14],
+            vec![Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]); 363],
+        ),
+    };
+    Ok(UnsignedPublishMessage::DepositSetup {
+        scope,
+        index: 1,
+        hash: sha256::Hash::hash(b"hash"),
+        funding_txid: Txid::all_zeros(),
+        funding_vout: 0,
+        operator_pk: XOnlyPublicKey::from_slice(&[2u8; 32]).unwrap(),
+        wots_pks,
+    })
+}
+
+/// Tests the gossip protocol in an all to all connected network with a single ID.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn all_to_all_message_size() -> anyhow::Result<()> {
+    const OPERATORS_NUM: usize = 2;
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
+    let Setup { mut operators, .. } = Setup::all_to_all(OPERATORS_NUM).await?;
+
+    let unsigned = real_deposit_setup()?;
+    let command: Command = unsigned.sign_secp256k1(&operators[0].kp).into();
+    operators[0].handle.send_command(command).await;
+
+    let event = operators[1].handle.next_event().await?;
+
+    if !matches!(
+        event,
+        Event::ReceivedMessage(GossipsubMsg {
+            unsigned: UnsignedGossipsubMsg::DepositSetup { .. },
+            ..
+        })
+    ) {
+        bail!("Got event other than the sent one - {:?}", event);
+    }
+
+    let (signature, key, message) = match event {
+        Event::ReceivedMessage(gossipsub_msg) => (
+            gossipsub_msg.signature.clone(),
+            gossipsub_msg.key.clone(),
+            gossipsub_msg.content(),
+        ),
+        _ => bail!("Got event other than the sent one - {:?}", event),
+    };
+
+    // Verify signature against key
+
+    assert!(key.verify(&message, &signature));
+
+    assert!(operators[1].handle.events_is_empty());
+
+    Ok(())
+}

--- a/crates/p2p/src/tests/mod.rs
+++ b/crates/p2p/src/tests/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod common;
 pub(crate) mod connect_peer;
 pub(crate) mod gossipsub;
 pub(crate) mod is_connected;
+pub(crate) mod message_size;
 pub(crate) mod request;

--- a/crates/types/src/deposit_data.rs
+++ b/crates/types/src/deposit_data.rs
@@ -54,9 +54,17 @@ impl WotsPublicKeys {
         fqs: Vec<Wots256PublicKey>,
         hashes: Vec<Wots128PublicKey>,
     ) -> Self {
+        let groth16 = Groth16PublicKeys::new(public_inputs, fqs, hashes);
+
+        // Verify the Groth16 public keys are not too large
+        assert!(
+            groth16.len() <= u16::MAX as usize,
+            "Groth16 public keys are too large, max is {}",
+            u16::MAX
+        );
         Self {
             withdrawal_fulfillment,
-            groth16: Groth16PublicKeys::new(public_inputs, fqs, hashes),
+            groth16,
         }
     }
 
@@ -81,6 +89,13 @@ impl WotsPublicKeys {
 
         // Parse the Groth16 public keys from the remaining bytes
         let groth16 = Groth16PublicKeys::from_flattened_bytes(&bytes[withdrawal_key_size..]);
+
+        // Verify the Groth16 public keys are not too large
+        assert!(
+            groth16.len() <= u16::MAX as usize,
+            "Groth16 public keys are too large, max is {}",
+            u16::MAX
+        );
 
         Self {
             withdrawal_fulfillment,
@@ -160,6 +175,23 @@ impl Groth16PublicKeys {
         fqs: Vec<Wots256PublicKey>,
         hashes: Vec<Wots128PublicKey>,
     ) -> Self {
+        // Verify the Groth16 public keys are not too large
+        assert!(
+            public_inputs.len() <= u16::MAX as usize,
+            "Public inputs are too large, max is {}",
+            u16::MAX
+        );
+        assert!(
+            fqs.len() <= u16::MAX as usize,
+            "Field elements are too large, max is {}",
+            u16::MAX
+        );
+        assert!(
+            hashes.len() <= u16::MAX as usize,
+            "Hashes are too large, max is {}",
+            u16::MAX
+        );
+
         Self {
             n_public_inputs: public_inputs.len() as u16,
             public_inputs,
@@ -170,7 +202,7 @@ impl Groth16PublicKeys {
         }
     }
 
-    /// Length of [`WotsPublicKeys`]
+    /// Length of [`Groth16PublicKeys`].
     pub fn len(&self) -> usize {
         (self.n_public_inputs + self.n_field_elements + self.n_hashes) as usize
     }
@@ -295,6 +327,37 @@ mod tests {
 
     use super::*;
     use crate::wots::wots_total_digits;
+
+    const N_PUBLIC_INPUTS: usize = 1;
+    const N_FIELD_ELEMENTS: usize = 14;
+    const N_HASHES: usize = 363;
+
+    fn big_groth16_public_keys() -> Groth16PublicKeys {
+        Groth16PublicKeys::new(
+            vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20]); N_PUBLIC_INPUTS],
+            vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); N_FIELD_ELEMENTS],
+            vec![Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]); N_HASHES],
+        )
+    }
+
+    #[test]
+    fn big_groth16_public_keys_len() {
+        let keys = big_groth16_public_keys();
+        assert_eq!(keys.len(), N_PUBLIC_INPUTS + N_FIELD_ELEMENTS + N_HASHES);
+    }
+
+    #[test]
+    #[should_panic(expected = "Hashes are too large, max is 65535")]
+    fn big_groth16_public_keys_len_panic() {
+        let _ = Groth16PublicKeys::new(
+            vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20]); N_PUBLIC_INPUTS],
+            vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); N_FIELD_ELEMENTS],
+            vec![
+                Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]);
+                u16::MAX as usize + 1
+            ],
+        );
+    }
 
     #[test]
     fn groth16_wots_flattened_bytes_roundtrip() {

--- a/crates/types/src/deposit_data.rs
+++ b/crates/types/src/deposit_data.rs
@@ -352,10 +352,7 @@ mod tests {
         let _ = Groth16PublicKeys::new(
             vec![Wots256PublicKey::from_flattened_bytes(&[2u8; 68 * 20]); N_PUBLIC_INPUTS],
             vec![Wots256PublicKey::from_flattened_bytes(&[3u8; 68 * 20]); N_FIELD_ELEMENTS],
-            vec![
-                Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]);
-                u16::MAX as usize + 1
-            ],
+            vec![Wots128PublicKey::from_flattened_bytes(&[4u8; 36 * 20]); u16::MAX as usize + 1],
         );
     }
 


### PR DESCRIPTION
## Description

This adds a test that reproduces the failed signature on real-world sized  Deposit Setup gossip messages.
The problem was that the `n_inputs` in `Groth16PublicKeys` are `u8`s and have a cap at `256` elements.
This PR makes all `n_inputs` `u16`s. And should fix the P2P issues that were experiencing with 300s of WOTS 128-bit keys.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers


## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
