### PR TITLE
STR-1248: nodes keep seeing duplicate gossip messages

### DIFF
--- a/crates/p2p/src/swarm/behavior.rs
+++ b/crates/p2p/src/swarm/behavior.rs
@@ -2,10 +2,11 @@
 
 use std::collections::HashSet;
 
+use bitcoin::hashes::{sha256, Hash};
 use libp2p::{
     allow_block_list::{AllowedPeers, Behaviour as AllowListBehaviour},
     gossipsub::{
-        self, Behaviour as Gossipsub, IdentityTransform, MessageAuthenticity,
+        self, Behaviour as Gossipsub, IdentityTransform, MessageAuthenticity, MessageId,
         WhitelistSubscriptionFilter,
     },
     identify::{Behaviour as Identify, Config},
@@ -69,6 +70,18 @@ impl Behaviour {
                     .max_transmit_size(MAX_TRANSMIT_SIZE)
                     // Avoids spamming the network and nodes with messages
                     .idontwant_on_publish(true)
+                    // We want a unique message id for each message, so we use the hash of the
+                    // message data instead of the default one, that is the concatenation of the
+                    // PeerId and the sequence number of the message.
+                    //
+                    // NOTE(@storopoli): I don't trust the default one, since we are not using the
+                    //                   LibP2P's Message template, hence the sequence number might
+                    //                   not exist, and in that case it is always be set to 0 by
+                    //                   default.
+                    .message_id_fn(|msg| {
+                        let hash = sha256::Hash::hash(msg.data.as_ref());
+                        MessageId::new(hash.as_ref())
+                    })
                     .build()
                     .expect("gossipsub config at this stage must be valid"),
                 None,

--- a/crates/p2p/src/swarm/behavior.rs
+++ b/crates/p2p/src/swarm/behavior.rs
@@ -67,6 +67,8 @@ impl Behaviour {
                     .validation_mode(gossipsub::ValidationMode::Permissive)
                     .validate_messages()
                     .max_transmit_size(MAX_TRANSMIT_SIZE)
+                    // Avoids spamming the network and nodes with messages
+                    .idontwant_on_publish(true)
                     .build()
                     .expect("gossipsub config at this stage must be valid"),
                 None,


### PR DESCRIPTION
## Description

- Adds a [IDONTWANT](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md#idontwant-message) on messages that a nodes publish, avoiding receiving it afterwards as a gossip. Enhances the efficiency of nodes and the network as a whole.
- Since the IDONTWANT is based on `MessageId`. This is by default computed by [concatenating the `PeerId` and the message sequence number](https://github.com/libp2p/rust-libp2p/blob/4a58542333297ae307c9cbe97d382979a39551b1/protocols/gossipsub/src/config.rs#L518-L531), which I don't think is a good default, especially since we don't follow the LibP2P's message template. Hence I don't know if the sequence number will be available, if it's not, then it will default to `0`. Conclusion: all the relevant messages about a certain txid might be rejected by the IDONTWANT (maybe, I don't know).

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This might incur some extra costs on the message production since we are hashing stuff now, instead of concatenating PeerId with a number, but it is no big deal for now.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1248
