### PR TITLE
fix(gossipsub): MessageId computation using BLAKE3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +515,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -3300,6 +3319,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitcoin",
+ "blake3",
  "futures",
  "libp2p",
  "musig2",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -25,6 +25,7 @@ libp2p = { workspace = true, features = [
 
 async-trait.workspace = true
 bitcoin = { workspace = true, features = ["serde"] }
+blake3 = "1.8.2"
 futures.workspace = true
 musig2 = { workspace = true, features = ["serde"] }
 prost.workspace = true

--- a/crates/p2p/src/swarm/behavior.rs
+++ b/crates/p2p/src/swarm/behavior.rs
@@ -2,10 +2,11 @@
 
 use std::collections::HashSet;
 
+use blake3::hash;
 use libp2p::{
     allow_block_list::{AllowedPeers, Behaviour as AllowListBehaviour},
     gossipsub::{
-        self, Behaviour as Gossipsub, IdentityTransform, MessageAuthenticity,
+        self, Behaviour as Gossipsub, IdentityTransform, MessageAuthenticity, MessageId,
         WhitelistSubscriptionFilter,
     },
     identify::{Behaviour as Identify, Config},
@@ -67,6 +68,20 @@ impl Behaviour {
                     .validation_mode(gossipsub::ValidationMode::Permissive)
                     .validate_messages()
                     .max_transmit_size(MAX_TRANSMIT_SIZE)
+                    // Avoids spamming the network and nodes with messages
+                    .idontwant_on_publish(true)
+                    // We want a unique message id for each message, so we use the hash of the
+                    // message data instead of the default one, that is the concatenation of the
+                    // PeerId and the sequence number of the message.
+                    //
+                    // NOTE(@storopoli): I don't trust the default one, since we are not using the
+                    //                   LibP2P's Message template, hence the sequence number might
+                    //                   not exist, and in that case it is always be set to 0 by
+                    //                   default.
+                    .message_id_fn(|msg| {
+                        let hash = hash(msg.data.as_ref());
+                        MessageId::new(hash.as_bytes())
+                    })
                     .build()
                     .expect("gossipsub config at this stage must be valid"),
                 None,


### PR DESCRIPTION
## Description

`MessageId` is, by default, computed by [concatenating the `PeerId` and the message sequence number](https://github.com/libp2p/rust-libp2p/blob/4a58542333297ae307c9cbe97d382979a39551b1/protocols/gossipsub/src/config.rs#L518-L531), which I don't think is a good default, especially since we don't follow the LibP2P's message template. Hence I don't know if the sequence number will be available, if it's not, then it will default to `0`.
This PR changes the computation of `MessageId` to be a hash using BLAKE3.

### Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This might incur some extra costs on the message production since we are hashing stuff now, instead of concatenating PeerId with a number, but it is no big deal for now.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1248
