### PR TITLE
fix(gossipsub): tweak configs to reduce duplicated msgs

### DIFF
--- a/crates/p2p/src/swarm/behavior.rs
+++ b/crates/p2p/src/swarm/behavior.rs
@@ -1,6 +1,6 @@
 //! Request-Response [`Behaviour`] and [`NetworkBehaviour`] for the P2P protocol.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use libp2p::{
     allow_block_list::{AllowedPeers, Behaviour as AllowListBehaviour},
@@ -68,7 +68,15 @@ impl Behaviour {
                     .validate_messages()
                     .max_transmit_size(MAX_TRANSMIT_SIZE)
                     // Avoids spamming the network and nodes with messages
-                    .idontwant_on_publish(true)
+                    .duplicate_cache_time(Duration::from_secs(60 * 5)) // default is 1 min
+                    .published_message_ids_cache_time(Duration::from_secs(60)) // default is 10
+                    .max_ihave_messages(100) // default is 10
+                    .gossip_retransimission(1) // default is 3
+                    .iwant_followup_time(Duration::from_secs(2)) // default is 3
+                    .gossip_lazy(2) // default is 6
+                    .gossip_factor(0.1) // default is 0.25
+                    .history_gossip(1) // default is 3
+                    .history_length(3) // default is 5
                     .build()
                     .expect("gossipsub config at this stage must be valid"),
                 None,


### PR DESCRIPTION
## Description

Tweaks some `gossipsub` configs from the default value to reduce message duplication across the P2P network.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers



## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
