### PR TITLE
chore(deps): move libp2p crates to pinned versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,8 +1597,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libp2p"
-version = "0.55.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
 dependencies = [
  "bytes",
  "either",
@@ -1631,7 +1632,8 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.5.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1640,8 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.5.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1650,8 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193c75710ba43f7504ad8f58a62ca0615b1d7e572cb0f1780bc607252c39e9ef"
 dependencies = [
  "either",
  "fnv",
@@ -1661,6 +1665,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
+ "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
@@ -1668,14 +1673,15 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.12",
  "tracing",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
 dependencies = [
  "async-trait",
  "futures",
@@ -1689,8 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -1719,8 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1760,7 +1768,8 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -1777,8 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.16.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1794,8 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1804,6 +1815,7 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "multihash",
+ "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
  "snow",
@@ -1817,7 +1829,8 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.46.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1831,8 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.12.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1852,8 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.28.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
 dependencies = [
  "async-trait",
  "futures",
@@ -1868,8 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
 dependencies = [
  "either",
  "fnv",
@@ -1880,6 +1896,7 @@ dependencies = [
  "libp2p-swarm-derive",
  "lru",
  "multistream-select",
+ "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -1889,10 +1906,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
 dependencies = [
  "heck",
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -1900,7 +1919,8 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1915,7 +1935,8 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -1933,7 +1954,8 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -1947,7 +1969,8 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
@@ -2143,7 +2166,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -2165,7 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2177,14 +2200,15 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
  "futures",
+ "log",
  "pin-project",
  "smallvec",
- "tracing",
- "unsigned-varint",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -2690,13 +2714,14 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 2.0.12",
- "unsigned-varint",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -3059,7 +3084,8 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
  "futures",
  "pin-project",
@@ -3306,7 +3332,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "hex",
- "libp2p",
+ "libp2p-identity",
  "proptest",
  "proptest-derive",
  "secp256k1",
@@ -3643,6 +3669,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ bitcoin = { version = "0.32.5", features = [ # keep in sync with secp256k1
 ] }
 futures = "0.3.31"
 hex = "0.4.3"
-# FIXME: tag a new release to solve RUSTSEC-2025-0009
-libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "b685b63dc6b98355d75234ff83a935ffa23d8eac", features = [
+libp2p = { version = "0.55.0", features = [
   "noise",
   "gossipsub",
   "tcp",
@@ -24,6 +23,11 @@ libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "b685b63dc6b
   "ping",
   "yamux",
   "identify",
+] }
+libp2p-identity = { version = "0.2.10", default-features = false, features = [
+  "secp256k1",
+  "peerid",
+  "rand",
 ] }
 musig2 = { version = "0.1.0", features = ["serde"] }
 prost = "0.13.4"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -17,7 +17,7 @@ rust.rust_2018_idioms = { level = "deny", priority = -1 }
 [dependencies]
 bitcoin.workspace = true
 hex = { workspace = true, features = ["serde"] }
-libp2p.workspace = true
+libp2p-identity.workspace = true
 proptest = { version = "1.6.0", optional = true }
 proptest-derive = { version = "0.5.1", optional = true }
 serde.workspace = true

--- a/crates/types/src/operator.rs
+++ b/crates/types/src/operator.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 
 use hex::ToHex;
-use libp2p::identity::secp256k1::PublicKey;
+use libp2p_identity::secp256k1::PublicKey;
 
 /// P2P [`P2POperatorPubKey`] serves as an identifier of protocol entity.
 ///


### PR DESCRIPTION
## Description

Moves to stable `libp2p` tagged crates.io versions.
Solves RUSTSEC-2025-0009.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

See https://github.com/libp2p/rust-libp2p/issues/5919#issuecomment-2839157118 for context.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1163
