### PR TITLE
fix(just): use cargo-hack

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -15,171 +15,29 @@ CARGO_TERM_COLOR := "always"
 default:
 	just --list
 
-# Show a friendly help menu
-help:
-	@echo ""
-	@echo "Available recipes:"
-	@echo "  lint               - Run all lints (clippy matrix, fmt check, codespell, taplo, actionlint, zizmor) in parallel"
-	@echo "  test-matrix        - Run feature matrix tests (nextest) in parallel"
-	@echo "  clippy-matrix      - Run feature matrix clippy in parallel"
-	@echo "  unit               - Run unit tests with coverage (llvm-cov + nextest)"
-	@echo "  docs               - Build docs"
-	@echo "  fmt-check          - Check formatting (rustfmt)"
-	@echo "  fmt-fix            - Auto-format (rustfmt)"
-	@echo "  codespell          - Lint spellings"
-	@echo "  taplo-lint         - Lint TOML files"
-	@echo "  taplo-fmt-check    - Check TOML formatting"
-	@echo "  audit              - Run cargo-audit (supply-chain)"
-	@echo "  actionlint         - Lint GitHub Actions workflows"
-	@echo "  zizmor             - Run zizmor (stdout)"
-	@echo "  zizmor-sarif       - Run zizmor (write results.sarif)"
-	@echo "  ci-all             - Run everything in parallel groups (lint + test-matrix + unit + docs)"
-	@echo ""
-	@echo "Helpers:"
-	@echo "  clippy-features FEATURES='' - Run clippy for a specific feature combo"
-	@echo "  test-features   FEATURES='' - Run nextest for a specific feature combo"
-	@echo ""
-
 # ----------------------------
 # Core linting & formatting
 # ----------------------------
 
-# Clippy on specific features (no-default-features)
-# Use RUSTFLAGS=-D warnings to fail on warnings, matching CI.
-[group('lint')]
-clippy-features FEATURES:
-	if [ -z "{{FEATURES}}" ]; then \
-		RUSTFLAGS="-D warnings" cargo clippy --workspace --lib --locked --examples --tests --benches --all-targets --no-default-features ; \
-	else \
-		RUSTFLAGS="-D warnings" cargo clippy --workspace --lib --locked --examples --tests --benches --all-targets --no-default-features --features "{{FEATURES}}" ; \
+# Helper to ensure cargo-hack is installed
+ensure-cargo-hack:
+	@if ! cargo hack --version > /dev/null 2>&1; then \
+		echo "Error: cargo-hack is not installed. Please install it by running: cargo install cargo-hack"; \
+		exit 1; \
 	fi
 
-# Non-BYOS clippy matrix entries
-[group('lint')]
-clippy-nonbyos-base:
-	just clippy-features ""
+# Helper to ensure cargo-nextest is installed
+ensure-cargo-nextest:
+	@if ! cargo nextest --version > /dev/null 2>&1; then \
+		echo "Installing cargo-nextest..."; \
+		cargo install cargo-nextest --locked; \
+	fi
 
-[group('lint')]
-clippy-nonbyos-gossipsub:
-	just clippy-features "gossipsub"
 
+# Run feature matrix clippy (cargo-hack)
 [group('lint')]
-clippy-nonbyos-request-response:
-	just clippy-features "request-response"
-
-[group('lint')]
-clippy-nonbyos-quic:
-	just clippy-features "quic"
-
-[group('lint')]
-clippy-nonbyos-kad:
-	just clippy-features "kad"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-request-response:
-	just clippy-features "gossipsub request-response"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-quic:
-	just clippy-features "gossipsub quic"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-kad:
-	just clippy-features "gossipsub kad"
-
-[group('lint')]
-clippy-nonbyos-request-response-quic:
-	just clippy-features "request-response quic"
-
-[group('lint')]
-clippy-nonbyos-request-response-kad:
-	just clippy-features "request-response kad"
-
-[group('lint')]
-clippy-nonbyos-quic-kad:
-	just clippy-features "quic kad"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-request-response-quic:
-	just clippy-features "gossipsub request-response quic"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-request-response-kad:
-	just clippy-features "gossipsub request-response kad"
-
-[group('lint')]
-clippy-nonbyos-gossipsub-quic-kad:
-	just clippy-features "gossipsub quic kad"
-
-[group('lint')]
-clippy-nonbyos-request-response-quic-kad:
-	just clippy-features "request-response quic kad"
-
-[group('lint')]
-clippy-nonbyos-all:
-	just clippy-features "gossipsub request-response quic kad"
-
-# BYOS clippy matrix entries (no kad)
-[group('lint')]
-clippy-byos-base:
-	just clippy-features "byos"
-
-[group('lint')]
-clippy-byos-gossipsub:
-	just clippy-features "byos gossipsub"
-
-[group('lint')]
-clippy-byos-request-response:
-	just clippy-features "byos request-response"
-
-[group('lint')]
-clippy-byos-quic:
-	just clippy-features "byos quic"
-
-[group('lint')]
-clippy-byos-gossipsub-request-response:
-	just clippy-features "byos gossipsub request-response"
-
-[group('lint')]
-clippy-byos-gossipsub-quic:
-	just clippy-features "byos gossipsub quic"
-
-[group('lint')]
-clippy-byos-request-response-quic:
-	just clippy-features "byos request-response quic"
-
-[group('lint')]
-clippy-byos-all:
-	just clippy-features "byos gossipsub request-response quic"
-
-# Run all clippy jobs in parallel
-[group('lint')]
-[parallel]
-clippy-matrix: \
-	clippy-nonbyos-base \
-	clippy-nonbyos-gossipsub \
-	clippy-nonbyos-request-response \
-	clippy-nonbyos-quic \
-	clippy-nonbyos-kad \
-	clippy-nonbyos-gossipsub-request-response \
-	clippy-nonbyos-gossipsub-quic \
-	clippy-nonbyos-gossipsub-kad \
-	clippy-nonbyos-request-response-quic \
-	clippy-nonbyos-request-response-kad \
-	clippy-nonbyos-quic-kad \
-	clippy-nonbyos-gossipsub-request-response-quic \
-	clippy-nonbyos-gossipsub-request-response-kad \
-	clippy-nonbyos-gossipsub-quic-kad \
-	clippy-nonbyos-request-response-quic-kad \
-	clippy-nonbyos-all \
-	clippy-byos-base \
-	clippy-byos-gossipsub \
-	clippy-byos-request-response \
-	clippy-byos-quic \
-	clippy-byos-gossipsub-request-response \
-	clippy-byos-gossipsub-quic \
-	clippy-byos-request-response-quic \
-	clippy-byos-all
+clippy-matrix: ensure-cargo-hack
+	RUSTFLAGS="-D warnings" cargo hack --feature-powerset --mutually-exclusive-features byos,kad clippy --workspace --lib --locked --examples --tests --benches --all-targets 
 
 # Format check / fix
 [group('lint')]
@@ -231,141 +89,10 @@ lint: clippy-matrix fmt-check codespell taplo-lint taplo-fmt-check actionlint zi
 # Tests & Docs
 # ----------------------------
 
-# Nextest on specific features (no-default-features)
+# Run feature matrix tests (nextest)
 [group('tests')]
-test-features FEATURES:
-	if [ -z "{{FEATURES}}" ]; then \
-		cargo nextest run --workspace --no-capture --no-default-features ; \
-	else \
-		cargo nextest run --workspace --no-capture --no-default-features --features "{{FEATURES}}" ; \
-	fi
-
-# Non-BYOS test matrix entries
-[group('tests')]
-test-nonbyos-base:
-	just test-features ""
-
-[group('tests')]
-test-nonbyos-gossipsub:
-	just test-features "gossipsub"
-
-[group('tests')]
-test-nonbyos-request-response:
-	just test-features "request-response"
-
-[group('tests')]
-test-nonbyos-quic:
-	just test-features "quic"
-
-[group('tests')]
-test-nonbyos-kad:
-	just test-features "kad"
-
-[group('tests')]
-test-nonbyos-gossipsub-request-response:
-	just test-features "gossipsub request-response"
-
-[group('tests')]
-test-nonbyos-gossipsub-quic:
-	just test-features "gossipsub quic"
-
-[group('tests')]
-test-nonbyos-gossipsub-kad:
-	just test-features "gossipsub kad"
-
-[group('tests')]
-test-nonbyos-request-response-quic:
-	just test-features "request-response quic"
-
-[group('tests')]
-test-nonbyos-request-response-kad:
-	just test-features "request-response kad"
-
-[group('tests')]
-test-nonbyos-quic-kad:
-	just test-features "quic kad"
-
-[group('tests')]
-test-nonbyos-gossipsub-request-response-quic:
-	just test-features "gossipsub request-response quic"
-
-[group('tests')]
-test-nonbyos-gossipsub-request-response-kad:
-	just test-features "gossipsub request-response kad"
-
-[group('tests')]
-test-nonbyos-gossipsub-quic-kad:
-	just test-features "gossipsub quic kad"
-
-[group('tests')]
-test-nonbyos-request-response-quic-kad:
-	just test-features "request-response quic kad"
-
-[group('tests')]
-test-nonbyos-all:
-	just test-features "gossipsub request-response quic kad"
-
-# BYOS test matrix entries (no kad)
-[group('tests')]
-test-byos-base:
-	just test-features "byos"
-
-[group('tests')]
-test-byos-gossipsub:
-	just test-features "byos gossipsub"
-
-[group('tests')]
-test-byos-request-response:
-	just test-features "byos request-response"
-
-[group('tests')]
-test-byos-quic:
-	just test-features "byos quic"
-
-[group('tests')]
-test-byos-gossipsub-request-response:
-	just test-features "byos gossipsub request-response"
-
-[group('tests')]
-test-byos-gossipsub-quic:
-	just test-features "byos gossipsub quic"
-
-[group('tests')]
-test-byos-request-response-quic:
-	just test-features "byos request-response quic"
-
-[group('tests')]
-test-byos-all:
-	just test-features "byos gossipsub request-response quic"
-
-# Run all test jobs in parallel
-[group('tests')]
-[parallel]
-test-matrix: \
-	test-nonbyos-base \
-	test-nonbyos-gossipsub \
-	test-nonbyos-request-response \
-	test-nonbyos-quic \
-	test-nonbyos-kad \
-	test-nonbyos-gossipsub-request-response \
-	test-nonbyos-gossipsub-quic \
-	test-nonbyos-gossipsub-kad \
-	test-nonbyos-request-response-quic \
-	test-nonbyos-request-response-kad \
-	test-nonbyos-quic-kad \
-	test-nonbyos-gossipsub-request-response-quic \
-	test-nonbyos-gossipsub-request-response-kad \
-	test-nonbyos-gossipsub-quic-kad \
-	test-nonbyos-request-response-quic-kad \
-	test-nonbyos-all \
-	test-byos-base \
-	test-byos-gossipsub \
-	test-byos-request-response \
-	test-byos-quic \
-	test-byos-gossipsub-request-response \
-	test-byos-gossipsub-quic \
-	test-byos-request-response-quic \
-	test-byos-all
+test-matrix: ensure-cargo-hack ensure-cargo-nextest
+	cargo hack --feature-powerset --mutually-exclusive-features byos,kad nextest run --workspace --no-capture 
 
 # Unit tests with coverage (similar to unit.yml)
 [group('tests')]

--- a/.justfile
+++ b/.justfile
@@ -92,7 +92,8 @@ lint: clippy-matrix fmt-check codespell taplo-lint taplo-fmt-check actionlint zi
 # Run feature matrix tests (nextest)
 [group('tests')]
 test-matrix: ensure-cargo-hack ensure-cargo-nextest
-	cargo hack --feature-powerset --mutually-exclusive-features byos,kad nextest run --workspace --no-capture 
+	RUST_LOG="INFO" RUST_BACKTRACE=1 cargo hack --feature-powerset --mutually-exclusive-features byos,kad nextest run --workspace 
+
 
 # Unit tests with coverage (similar to unit.yml)
 [group('tests')]


### PR DESCRIPTION
## Description

Removes the bunch of ad-hoc `just` recipes to a single one that uses `cargo-hack` for `clippy` and `tests`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers



## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
